### PR TITLE
Add UDP echo test and implementation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,13 @@ dnsproxy_sources = [
 ]
 dnsproxy_exec = executable('dnsproxy', dnsproxy_sources)
 
+# DNS Echo
+dnsecho_sources = [
+  'src/udp.c',
+  'src/dnsecho.c'
+]
+dnsecho_exec = executable('dnsecho', dnsecho_sources)
+
 # Declare project dependencies here, for example:
 check_dep = dependency('check')
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,8 @@
-project('dnsproxy', 'c')
+project(
+  'dnsproxy',
+  'c',
+  default_options: ['warning_level=3']
+)
 
 # Declare how to build the main project
 dnsproxy_sources = [

--- a/src/dnsecho.c
+++ b/src/dnsecho.c
@@ -1,0 +1,46 @@
+#include "udp.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/epoll.h>
+
+int epoll_setup_in(const int socket){
+    int epoll_fd;
+
+    // create epoll instance
+    epoll_fd = epoll_create1(0);
+    if (epoll_fd == -1) {
+        return epoll_fd;
+    }
+
+    struct epoll_event event;
+    event.events =  EPOLLIN; // we are interested in read events
+    event.data.fd = socket;
+
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, socket, &event) == -1) {
+        return -1;
+    }
+    return epoll_fd;
+}
+
+
+int main(void){
+    int fd = create_udp_listener(5301);
+    struct epoll_event events[10];
+
+    int epoll_fd = epoll_setup_in(fd);
+
+    while (1) {
+        // wait indefinetly for an event
+        // this call blocks
+        int n = epoll_wait(epoll_fd, events, 10, -1);
+
+        // handle events
+        for (int i = 0; i < n; i++) {
+            char buf[51];
+            if (udp_echo(fd, buf, 51) == -1){
+                perror("unable to echo UDP message");
+                exit(1);
+            }
+        }
+    }
+}

--- a/src/udp.c
+++ b/src/udp.c
@@ -1,6 +1,9 @@
 #include <arpa/inet.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 // Create a listening socket
 int create_udp_listener(int port) {
@@ -21,4 +24,22 @@ int create_udp_listener(int port) {
     }
 
     return listen_fd;
+}
+
+int udp_echo(int socket, char* buf, size_t buflen){
+    struct sockaddr_in caddr; // client addres
+    socklen_t caddrlen = sizeof(caddr);
+    memset((char *)&caddr, 0, caddrlen);
+
+    int recv_len;
+    if ((recv_len = recvfrom(socket, buf, buflen, 0, (struct sockaddr *)&caddr, &caddrlen)) == -1) {
+        return -1;
+    }
+
+    int sent_len;
+    if ((sent_len = sendto(socket, buf, buflen, 0, (struct sockaddr*)&caddr, caddrlen)) == -1){
+         return -1;
+    }
+
+    return sent_len;
 }

--- a/src/udp.h
+++ b/src/udp.h
@@ -2,5 +2,6 @@
 #define UDP_H_
 
 int create_udp_listener(int port);
+int udp_echo(int socket, char* buf, int buflen);
 
 #endif // UDP_H_

--- a/tests/udp_test.c
+++ b/tests/udp_test.c
@@ -1,11 +1,75 @@
 #include <check.h>
 #include <netinet/in.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <errno.h>
+#include <time.h>
 #include "../src/udp.h"
+
+char *generate_random_string(size_t length) {
+    const char charset[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    char *str = malloc(length + 1);
+    if (str == NULL) {
+        return NULL; // Allocation failed
+    }
+
+    srand(time(0));
+    for (size_t i = 0; i < length; ++i) {
+        int index = rand() % (sizeof(charset) - 1);
+        str[i] = charset[index];
+    }
+    str[length] = '\0'; // Null-terminate the string
+
+    return str;
+}
+
+
+int send_via_udp(int port, const char* buf, size_t buflen){
+    struct sockaddr_in client_addr;
+    client_addr.sin_family = AF_INET;
+    client_addr.sin_port = htons(port);
+    client_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    int client_fd = socket(AF_INET, SOCK_DGRAM, 0);
+
+    size_t len;
+    if ((len = sendto(client_fd, buf, buflen, 0,
+                (struct sockaddr*)&client_addr, sizeof(client_addr))) == -1){
+        return -1;
+    }
+
+    return client_fd;
+}
+
+START_TEST(test_udp_echo)
+{
+                                        // max udp payload is 65507 Bytes
+                                        // flip 0 to 1 to make this test fail
+    char *want = generate_random_string(65507 + 0);
+    int want_l = strlen(want);
+    char got[want_l];
+
+    int port = 5299;
+    int fd = create_udp_listener(port);
+    ck_assert_int_ge(fd, 0);
+
+    int client_fd;
+    client_fd = send_via_udp(port, want, want_l);
+    ck_assert_msg(client_fd != -1, "unable to send message via udp");
+
+    // echo the message
+    udp_echo(fd, got, want_l);
+
+    // receive the test message in the listener socket
+    recvfrom(client_fd, got, want_l, 0, NULL, NULL);
+
+    //check
+    got[want_l] = '\0';
+    ck_assert_str_eq(want, got);
+    free(want);
+}
 
 START_TEST(test_create_udp_listener)
 {
@@ -35,24 +99,20 @@ START_TEST(udp_conn)
     int fd = create_udp_listener(port);
     ck_assert_msg(fd != -1, "unable to create UDP listener");
 
-    // create a client socket to send a test message
-    struct sockaddr_in client_addr;
-    client_addr.sin_family = AF_INET;
-    client_addr.sin_port = htons(port);
-    client_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    char* want = generate_random_string(10000);
+    int want_s = strlen(want);
+    char got[want_s];
 
-    int client_fd = socket(AF_INET, SOCK_DGRAM, 0);
-    const char *msg = "test";
-    sendto(client_fd, msg, strlen(msg), 0,
-           (struct sockaddr*)&client_addr, sizeof(client_addr));
+    int client_fd = send_via_udp(port, want, want_s);
+    ck_assert_msg(client_fd != -1, "unable to send udp message");
 
     // receive the test message in the listener socket
-    char buff[strlen(msg)];
-    recvfrom(fd, buff, sizeof(buff), 0, NULL, NULL);
+    recvfrom(fd, got, sizeof(got), 0, NULL, NULL);
 
     // check that what we read from the fd into the buff is the same
     // message that we sent.
-    ck_assert_str_eq(buff, msg);
+    got[want_s] = '\0';
+    ck_assert_str_eq(want, got);
 
     close(fd);
     close(client_fd);
@@ -69,6 +129,7 @@ Suite* suite(void)
     tcase_add_test(tc, test_create_udp_listener);
     tcase_add_test(tc, test_create_listener_used_port);
     tcase_add_test(tc, udp_conn);
+    tcase_add_test(tc, test_udp_echo);
 
     suite_add_tcase(s, tc);
 

--- a/tests/udp_test.c
+++ b/tests/udp_test.c
@@ -34,7 +34,7 @@ int send_via_udp(int port, const char* buf, size_t buflen){
     client_addr.sin_addr.s_addr = htonl(INADDR_ANY);
     int client_fd = socket(AF_INET, SOCK_DGRAM, 0);
 
-    size_t len;
+    int len;
     if ((len = sendto(client_fd, buf, buflen, 0,
                 (struct sockaddr*)&client_addr, sizeof(client_addr))) == -1){
         return -1;


### PR DESCRIPTION
### build setup
```meson
~/w/ewdns ❯❯❯ meson setup build
The Meson build system
Version: 1.2.1
Source dir: /home/walter/workspace/ewdns
Build dir: /home/walter/workspace/ewdns/build
Build type: native build
Project name: dnsproxy
Project version: undefined
C compiler for the host machine: cc (gcc 13.2.0 "cc (Debian 13.2.0-2) 13.2.0")
C linker for the host machine: cc ld.bfd 2.41
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: /usr/bin/pkg-config (1.8.1)
Run-time dependency check found: YES 0.15.2
Build targets in project: 3

Found ninja-1.11.1 at /usr/bin/ninja
```

### testing
```meson
~/w/ewdns ❯❯❯ meson test -C build
ninja: Entering directory `/home/walter/workspace/ewdns/build'
[6/6] Linking target udp_test
1/2 utils_test        OK              0.01s
2/2 udp_test          OK              0.01s

Ok:                 2   
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   
```

### dnsecho
```
./build/dnsecho
```
```
dig @localhost -p 5301 ve -4 +yaml | wl-copy
```
```yaml
-
  type: MESSAGE
  message:
    type: AUTH_RESPONSE
    query_time: !!timestamp 2023-09-16T00:36:57.328Z
    response_time: !!timestamp 2023-09-16T00:36:57.328Z
    message_size: 51b
    socket_family: INET
    socket_protocol: UDP
    response_address: "127.0.0.1"
    response_port: 5301
    query_address: "0.0.0.0"
    query_port: 0
    response_message_data:
      opcode: QUERY
      status: NOERROR
      id: 45834
      flags: rd ad
      QUESTION: 1
      ANSWER: 0
      AUTHORITY: 0
      ADDITIONAL: 1
      OPT_PSEUDOSECTION:
        EDNS:
          version: 0
          flags:
          udp: 1232
          COOKIE: 814b543e56fedf5c (echoed)
      QUESTION_SECTION:
        - ve. IN A
```